### PR TITLE
feat: add missing .env.local.example file

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,11 @@
+# Open Researcher Environment Variables
+# Copy this file to .env.local and fill in your actual API keys
+
+# Required: Anthropic API key for Claude AI functionality
+# Get yours at: https://console.anthropic.com/
+ANTHROPIC_API_KEY=your_anthropic_api_key_here
+
+# Optional: Firecrawl API key for web scraping
+# If not provided, you can add it through the UI
+# Get yours at: https://www.firecrawl.dev/
+FIRECRAWL_API_KEY=your_firecrawl_api_key_here

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.local.example
 
 # vercel
 .vercel


### PR DESCRIPTION
This pull request adds an example `.env.local` file to guide developers in setting up required and optional API keys for the project. The file provides placeholders and instructions for configuring the Anthropic and Firecrawl API keys.

Environment variable setup:

* [`.env.local.example`](diffhunk://#diff-51db1e9260201708554a6d042039c4cd3366a090e6d2c3c59f281b22740dc7d6R1-R11): Added example environment variables for `ANTHROPIC_API_KEY` (required for Claude AI functionality) and `FIRECRAWL_API_KEY` (optional for web scraping), along with instructions on where to obtain these keys.