### PR TITLE
fix: input text color in dark mode

### DIFF
--- a/components/thinking-chat.tsx
+++ b/components/thinking-chat.tsx
@@ -341,7 +341,7 @@ export function ThinkingChat({ onMessagesChange, hasFirecrawlKey = false, onApiK
               onFocus={() => setShowSuggestions(true)}
               onBlur={() => setTimeout(() => setShowSuggestions(false), 200)}
               placeholder="Enter query..."
-              className="w-full h-12 rounded-full border border-zinc-200 bg-white pl-5 pr-14 text-base ring-offset-white file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-zinc-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:border-zinc-800 dark:bg-zinc-950 dark:ring-offset-zinc-950 dark:placeholder:text-zinc-400 dark:focus-visible:ring-orange-400 shadow-sm"
+              className="w-full h-12 rounded-full border border-zinc-200 bg-white pl-5 pr-14 text-base text-zinc-900 dark:text-zinc-100 ring-offset-white file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-zinc-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:border-zinc-800 dark:bg-zinc-950 dark:ring-offset-zinc-950 dark:placeholder:text-zinc-400 dark:focus-visible:ring-orange-400 shadow-sm"
               disabled={isSearching}
             />
             <button
@@ -550,7 +550,7 @@ export function ThinkingChat({ onMessagesChange, hasFirecrawlKey = false, onApiK
                 value={input}
                 onChange={(e) => setInput(e.target.value)}
                 placeholder="Enter query..."
-                className="w-full h-12 rounded-full border border-zinc-200 bg-white pl-5 pr-14 text-base ring-offset-white file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-zinc-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:border-zinc-800 dark:bg-zinc-950 dark:ring-offset-zinc-950 dark:placeholder:text-zinc-400 dark:focus-visible:ring-orange-400 shadow-sm"
+                className="w-full h-12 rounded-full border border-zinc-200 bg-white pl-5 pr-14 text-base text-zinc-900 dark:text-zinc-100 ring-offset-white file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-zinc-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:border-zinc-800 dark:bg-zinc-950 dark:ring-offset-zinc-950 dark:placeholder:text-zinc-400 dark:focus-visible:ring-orange-400 shadow-sm"
                 disabled={isSearching}
               />
               <button


### PR DESCRIPTION
This pull request includes updates to the `ThinkingChat` component to improve text visibility in both light and dark themes. The changes ensure that text color is explicitly defined for better contrast and readability.

## Screenshots

### Current
<img width="781" alt="Screenshot 2025-07-02 at 8 05 14 PM" src="https://github.com/user-attachments/assets/b988566d-a17b-4089-ae9b-fb75ab8bfadd" />

### Fix

<img width="814" alt="Screenshot 2025-07-02 at 8 06 58 PM" src="https://github.com/user-attachments/assets/330e64ba-5a6e-41d2-b89b-902ac44df41f" />

Styling improvements:

* Updated the `className` property for the input field at two locations in `ThinkingChat` to explicitly set text color (`text-zinc-900` for light mode and `dark:text-zinc-100` for dark mode). This ensures consistent and readable text across themes. (`components/thinking-chat.tsx`, [[1]](diffhunk://#diff-8697f46f542936b98ec4aeb3f28d13934e6a472bf2564e01481b414b0d54a930L344-R344) [[2]](diffhunk://#diff-8697f46f542936b98ec4aeb3f28d13934e6a472bf2564e01481b414b0d54a930L553-R553)
